### PR TITLE
Working environment for regridding

### DIFF
--- a/conda/regrid_env.yaml
+++ b/conda/regrid_env.yaml
@@ -18,8 +18,9 @@ dependencies:
 # regrid
     - xesmf
 # other plotting and interaction
-    - jupyter
+    - jupyterlab
     - cartopy
+    - shapely
 # filesystem
     - fsspec
     - s3fs


### PR DESCRIPTION
`shapely` probably isn't necessary, but `jupyter` -> `jupyterlab` fixes the conflict that causes it to fail to solve (after taking an eternity and a half).